### PR TITLE
Fix conda environment for docs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - ipywidgets
   - matplotlib
   - numpy>=1.11
+  - numpydoc
   - pandas
   - plotly
   - scipy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-numpy
 numpydoc
 sphinx


### PR DESCRIPTION
The docs for this branch have been built successfully at http://lens.readthedocs.io/en/docs/