### PR TITLE
Replace broken Plotly plots in widget with matplotlib

### DIFF
--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+from matplotlib.ticker import FuncFormatter, MaxNLocator
 import numpy as np
 import plotly.graph_objs as go
 try:
@@ -56,6 +57,74 @@ def plot_distribution(ls, column, bins=None):
     ax.set_title('Distribution of column "{}"'.format(column))
 
     ax.figure.tight_layout()
+
+    return fig
+
+
+def _set_integer_tick_labels(axis, labels):
+    """Use labels dict to set labels on axis"""
+    axis.set_major_formatter(FuncFormatter(lambda x, _: labels.get(x, '')))
+    axis.set_major_locator(MaxNLocator(integer=True))
+
+
+def plot_pairdensity_mpl(ls, column1, column2):
+    """Plot the pairwise density between two columns.
+
+    This plot is an approximation of a scatterplot through a 2D Kernel
+    Density Estimate for two numerical variables. When one of the variables
+    is categorical, a 1D KDE for each of the categories is shown,
+    normalised to the total number of non-null observations. For two
+    categorical variables, the plot produced is a heatmap representation of
+    the contingency table.
+
+    Parameters
+    ----------
+    ls : :class:`~lens.Summary`
+        Lens `Summary`.
+    column1 : str
+        First column.
+    column2 : str
+        Second column.
+
+    Returns
+    -------
+    :class:`plt.Figure`
+        Matplotlib figure containing the pairwise density plot.
+    """
+    pair_details = ls.pair_details(column1, column2)
+    pairdensity = pair_details['pairdensity']
+
+    x = np.array(pairdensity['x'])
+    y = np.array(pairdensity['y'])
+    Z = np.array(pairdensity['density'])
+
+    fig, ax = plt.subplots()
+
+    if ls.summary(column1)['desc'] == 'categorical':
+        idx = np.argsort(x)
+        x = x[idx]
+        Z = Z[:, idx]
+        # Create labels and positions for categorical axis
+        x_labels = dict(enumerate(x))
+        _set_integer_tick_labels(ax.xaxis, x_labels)
+        x = np.arange(-0.5, len(x), 1.0)
+
+    if ls.summary(column2)['desc'] == 'categorical':
+        idx = np.argsort(y)
+        y = y[idx]
+        Z = Z[idx]
+        y_labels = dict(enumerate(y))
+        _set_integer_tick_labels(ax.yaxis, y_labels)
+        y = np.arange(-0.5, len(y), 1.0)
+
+    X, Y = np.meshgrid(x, y)
+
+    ax.pcolormesh(X, Y, Z, cmap=DEFAULT_COLORSCALE.lower())
+
+    ax.set_xlabel(column1)
+    ax.set_ylabel(column2)
+
+    ax.set_title(r'$\it{{ {} }}$ vs $\it{{ {} }}$'.format(column1, column2))
 
     return fig
 

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -301,7 +301,8 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
         ax=ax,
         xticklabels=columns, yticklabels=columns,
         vmin=-1, vmax=1,
-        cmap='RdBu_r'
+        cmap='RdBu_r',
+        square=True
     )
 
     ax.xaxis.tick_top()

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -131,6 +131,93 @@ def plot_pairdensity_mpl(ls, column1, column2):
     return fig
 
 
+def plot_correlation_mpl(ls, include=None, exclude=None):
+    """Plot the correlation matrix for numeric columns
+
+    Plot a Spearman rank order correlation coefficient matrix showing the
+    correlation between columns. The matrix is reordered to group together
+    columns that have a higher correlation coefficient.  The columns to be
+    plotted in the correlation plot can be selected through either the
+    ``include`` or ``exclude`` keyword arguments. Only one of them can be
+    given.
+
+    Parameters
+    ----------
+    ls : :class:`~lens.Summary`
+        Lens `Summary`.
+    include : list of str
+        List of columns to include in the correlation plot.
+    exclude : list of str
+        List of columns to exclude from the correlation plot.
+
+    Returns
+    -------
+    :class:`plt.Figure`
+        Matplotlib figure containing the pairwise density plot.
+    """
+
+    columns, correlation_matrix = ls.correlation_matrix(include, exclude)
+    num_cols = len(columns)
+
+    if num_cols > 10:
+        annotate = False
+    else:
+        annotate = True
+
+    fig, ax = plt.subplots()
+    sns.heatmap(correlation_matrix,annot=annotate, fmt='.2f', ax=ax,
+                xticklabels=columns, yticklabels=columns, vmin=-1, vmax=1,
+                cmap='RdBu_r', square=True)
+
+    ax.xaxis.tick_top()
+
+    w = len(columns) * 2.5
+    while w > 10:
+        w /= np.sqrt(1.4)
+
+    fig.set_size_inches(w, w)
+
+    return fig
+
+
+def plot_cdf(ls, column, N_cdf=100):
+    """Plot the empirical cumulative distribution function of a column.
+
+    Creates a plotly plot with the empirical CDF of a column.
+
+    Parameters
+    ----------
+    ls : :class:`~lens.Summary`
+        Lens `Summary`.
+    column : str
+        Name of the column.
+    N_cdf : int
+        Number of points in the CDF plot.
+
+    Returns
+    -------
+    :class:`~matplotlib.Axes`
+        Matplotlib axes containing the distribution plot.
+    """
+    tdigest = ls.tdigest(column)
+
+    cdfs = np.linspace(0, 100, N_cdf)
+    xs = [tdigest.percentile(p) for p in cdfs]
+
+    fig, ax = plt.subplots()
+
+    ax.set_ylabel('Percentile')
+    ax.set_xlabel(column)
+    ax.plot(xs, cdfs)
+
+    if ls._report['column_summary'][column]['logtrans']:
+        ax.set_xscale('log')
+
+    ax.set_title('Empirical Cumulative Distribution Function')
+
+    return fig
+
+
 def plot_pairdensity(ls, column1, column2):
     """Plot the pairwise density between two columns.
 
@@ -259,96 +346,5 @@ def plot_correlation(ls, include=None, exclude=None):
     fig.layout['width'] = w
     fig.layout['height'] = w
     fig.data[0]['showscale'] = True
-
-    return fig
-
-
-def plot_correlation_mpl(ls, include=None, exclude=None):
-    """Plot the correlation matrix for numeric columns
-
-    Plot a Spearman rank order correlation coefficient matrix showing the
-    correlation between columns. The matrix is reordered to group together
-    columns that have a higher correlation coefficient.  The columns to be
-    plotted in the correlation plot can be selected through either the
-    ``include`` or ``exclude`` keyword arguments. Only one of them can be
-    given.
-
-    Parameters
-    ----------
-    ls : :class:`~lens.Summary`
-        Lens `Summary`.
-    include : list of str
-        List of columns to include in the correlation plot.
-    exclude : list of str
-        List of columns to exclude from the correlation plot.
-
-    Returns
-    -------
-    :class:`plt.Figure`
-        Matplotlib figure containing the pairwise density plot.
-    """
-
-    columns, correlation_matrix = ls.correlation_matrix(include, exclude)
-    num_cols = len(columns)
-
-    if num_cols > 10:
-        annotate = False
-    else:
-        annotate = True
-
-    fig, ax = plt.subplots()
-    sns.heatmap(correlation_matrix,annot=annotate,
-        fmt='.2f',
-        ax=ax,
-        xticklabels=columns, yticklabels=columns,
-        vmin=-1, vmax=1,
-        cmap='RdBu_r',
-        square=True
-    )
-
-    ax.xaxis.tick_top()
-
-    w = len(columns) * 2.5
-    while w > 10:
-        w /= np.sqrt(1.4)
-
-    fig.set_size_inches(w, w)
-
-    return fig
-
-def plot_cdf(ls, column, N_cdf=100):
-    """Plot the empirical cumulative distribution function of a column.
-
-    Creates a plotly plot with the empirical CDF of a column.
-
-    Parameters
-    ----------
-    ls : :class:`~lens.Summary`
-        Lens `Summary`.
-    column : str
-        Name of the column.
-    N_cdf : int
-        Number of points in the CDF plot.
-
-    Returns
-    -------
-    :class:`~matplotlib.Axes`
-        Matplotlib axes containing the distribution plot.
-    """
-    tdigest = ls.tdigest(column)
-
-    cdfs = np.linspace(0, 100, N_cdf)
-    xs = [tdigest.percentile(p) for p in cdfs]
-
-    fig, ax = plt.subplots()
-
-    ax.set_ylabel('Percentile')
-    ax.set_xlabel(column)
-    ax.plot(xs, cdfs)
-
-    if ls._report['column_summary'][column]['logtrans']:
-        ax.set_xscale('log')
-
-    ax.set_title('Empirical Cumulative Distribution Function')
 
     return fig

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -295,26 +295,16 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
     else:
         annotate = True
 
-    if annotate:
-        t = np.reshape(
-            ['{:.2g}'.format(x) for x in correlation_matrix.flatten()],
-            correlation_matrix.shape
-        )[::-1].tolist()
-    else:
-        nrows, ncolumns = correlation_matrix.shape
-        t = [
-            ['' for i in range(nrows)]
-            for j in range(ncolumns)
-        ]
-
     fig, ax = plt.subplots()
     sns.heatmap(correlation_matrix,annot=annotate,
         fmt='.2g',
         ax=ax,
         xticklabels=columns, yticklabels=columns,
         vmin=-1, vmax=1,
-        cmap='RdBu'
+        cmap='BuRd'
     )
+
+    ax.xaxis.tick_top()
 
     w = len(columns) * 2.5 
     while w > 10:

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter, MaxNLocator
 import numpy as np
 import plotly.graph_objs as go
+import seaborn as sns
 try:
     import plotly.figure_factory as pff
 except ImportError:
@@ -260,6 +261,68 @@ def plot_correlation(ls, include=None, exclude=None):
 
     return fig
 
+
+def plot_correlation_mpl(ls, include=None, exclude=None):
+    """Plot the correlation matrix for numeric columns
+
+    Plot a Spearman rank order correlation coefficient matrix showing the
+    correlation between columns. The matrix is reordered to group together
+    columns that have a higher correlation coefficient.  The columns to be
+    plotted in the correlation plot can be selected through either the
+    ``include`` or ``exclude`` keyword arguments. Only one of them can be
+    given.
+
+    Parameters
+    ----------
+    ls : :class:`~lens.Summary`
+        Lens `Summary`.
+    include : list of str
+        List of columns to include in the correlation plot.
+    exclude : list of str
+        List of columns to exclude from the correlation plot.
+
+    Returns
+    -------
+    :class:`plt.Figure`
+        Matplotlib figure containing the pairwise density plot.
+    """
+
+    columns, correlation_matrix = ls.correlation_matrix(include, exclude)
+    num_cols = len(columns)
+
+    if num_cols > 10:
+        annotate = False
+    else:
+        annotate = True
+
+    if annotate:
+        t = np.reshape(
+            ['{:.2g}'.format(x) for x in correlation_matrix.flatten()],
+            correlation_matrix.shape
+        )[::-1].tolist()
+    else:
+        nrows, ncolumns = correlation_matrix.shape
+        t = [
+            ['' for i in range(nrows)]
+            for j in range(ncolumns)
+        ]
+
+    fig, ax = plt.subplots()
+    sns.heatmap(correlation_matrix,annot=annotate,
+        fmt='.2g',
+        ax=ax,
+        xticklabels=columns, yticklabels=columns,
+        vmin=-1, vmax=1,
+        cmap='RdBu'
+    )
+
+    w = len(columns) * 2.5 * 72
+    while w > 600:
+        w /= np.sqrt(1.4)
+
+    fig.set_size_inches(w, w)
+
+    return fig
 
 def plot_cdf(ls, column, N_cdf=100):
     """Plot the empirical cumulative distribution function of a column.

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -50,7 +50,7 @@ def plot_distribution(ls, column, bins=None):
 
     fig, ax = plt.subplots()
 
-    ax.bar(edges[:-1], counts, width=np.diff(edges), label=column, alpha=0.4,
+    ax.bar(edges[:-1], counts, width=np.diff(edges), label=column,
            align='edge')
 
     ax.set_ylim(bottom=0)

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -165,7 +165,7 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
         annotate = True
 
     fig, ax = plt.subplots()
-    sns.heatmap(correlation_matrix,annot=annotate, fmt='.2f', ax=ax,
+    sns.heatmap(correlation_matrix, annot=annotate, fmt='.2f', ax=ax,
                 xticklabels=columns, yticklabels=columns, vmin=-1, vmax=1,
                 cmap='RdBu_r', square=True)
 

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -172,12 +172,12 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
     ax.xaxis.tick_top()
 
     # Enforces a width of 2.5 inches per cell in the plot,
-    # unless this exceeds 600 pixels.
-    w = len(columns) * 2.5
-    while w > 10:
-        w /= np.sqrt(1.4)
+    # unless this exceeds 10 inches.
+    width_inches = len(columns) * 2.5
+    while width_inches > 10:
+        width_inches = 10
 
-    fig.set_size_inches(w, w)
+    fig.set_size_inches(width_inches, width_inches)
 
     return fig
 

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -171,6 +171,8 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
 
     ax.xaxis.tick_top()
 
+    # Enforces a width of 2.5 inches per cell in the plot,
+    # unless this exceeds 600 pixels.
     w = len(columns) * 2.5
     while w > 10:
         w /= np.sqrt(1.4)

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -316,8 +316,8 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
         cmap='RdBu'
     )
 
-    w = len(columns) * 2.5 * 72
-    while w > 600:
+    w = len(columns) * 2.5 
+    while w > 10:
         w /= np.sqrt(1.4)
 
     fig.set_size_inches(w, w)

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -50,7 +50,8 @@ def plot_distribution(ls, column, bins=None):
 
     fig, ax = plt.subplots()
 
-    ax.bar(edges[:-1], counts, width=np.diff(edges), label=column, alpha=0.4)
+    ax.bar(edges[:-1], counts, width=np.diff(edges), label=column, alpha=0.4,
+           align='edge')
 
     ax.set_ylim(bottom=0)
 
@@ -307,7 +308,7 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
 
     ax.xaxis.tick_top()
 
-    w = len(columns) * 2.5 
+    w = len(columns) * 2.5
     while w > 10:
         w /= np.sqrt(1.4)
 

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -297,7 +297,7 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
 
     fig, ax = plt.subplots()
     sns.heatmap(correlation_matrix,annot=annotate,
-        fmt='.2g',
+        fmt='.2f',
         ax=ax,
         xticklabels=columns, yticklabels=columns,
         vmin=-1, vmax=1,

--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -301,7 +301,7 @@ def plot_correlation_mpl(ls, include=None, exclude=None):
         ax=ax,
         xticklabels=columns, yticklabels=columns,
         vmin=-1, vmax=1,
-        cmap='BuRd'
+        cmap='RdBu_r'
     )
 
     ax.xaxis.tick_top()

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -116,7 +116,7 @@ def _simple_columnwise_widget(ls, plot_function, columns):
     """Basic column-wise plot widget"""
 
     dropdown = widgets.Dropdown(options=columns, description='Column:')
-    plot_area = widget.Output()
+    plot_area = widgets.Output()
     update_plot(plot_function, [ls, columns[0]], plot_area, height=500)
 
     dropdown.observe(lambda x: update_plot(plot_function, [ls, x['new']],

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -28,13 +28,16 @@ def update_plot(f, args, plot_area, **kwargs):
     """Updates the content of an output widget with rendered function"""
 
     fig = f(*args)
-    fig.set_size_inches(PLOT_WIDTH / DPI, PLOT_HEIGHT / DPI)
     plot_area.clear_output()
 
-    if 'height' in kwargs.keys():
-        plot_area.layout.height = '{:.0f}px'.format(kwargs['height'])
-    if 'width' in kwargs.keys():
-        plot_area.layout.width = '{:.0f}px'.format(kwargs['width'])
+    height = kwargs.get('height', PLOT_HEIGHT)
+    width = kwargs.get('width', PLOT_WIDTH)
+    dpi = kwargs.get('dpi', DPI)
+
+    fig.set_size_inches(width / dpi, height / dpi)
+    
+    plot_area.layout.height = '{:.0f}px'.format(height)
+    plot_area.layout.width = '{:.0f}px'.format(width)
 
     with plot_area:
         display(fig)
@@ -59,7 +62,7 @@ def create_correlation_plot_widget(ls):
     update_plot(plot_correlation_mpl,
         [ls],
         plot_area,
-        height=PLOT_HEIGHT, width=PLOT_HEIGHT
+        height=PLOT_WIDTH, width=PLOT_WIDTH
         )
 
     return plot_area

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -58,11 +58,17 @@ def create_correlation_plot_widget(ls):
 
 def update_plot(f, args, html_area, **kwargs):
     """Updates the content of an html_area with rendered function"""
-    html_area.value = render_plotly_js(f(*args), **kwargs)
+
+    figure = f(*args, **kwargs)    
+    output_widget.clear_output()
+    
     if 'height' in kwargs.keys():
-        html_area.height = '{:.0f}px'.format(kwargs['height'])
+        output_widget.layout.height = '{:.0f}px'.format(kwargs['height'])
     if 'width' in kwargs.keys():
-        html_area.width = '{:.0f}px'.format(kwargs['width'])
+        output_widget.layout.width = '{:.0f}px'.format(kwargs['width'])
+        
+    with output_widget:
+        display(figure)
 
 
 def _update_pairdensity_plot(ls, dd1, dd2, plot_area):
@@ -110,7 +116,7 @@ def _simple_columnwise_widget(ls, plot_function, columns):
     """Basic column-wise plot widget"""
 
     dropdown = widgets.Dropdown(options=columns, description='Column:')
-    plot_area = widgets.HTML()
+    plot_area = widget.Output()
     update_plot(plot_function, [ls, columns[0]], plot_area, height=500)
 
     dropdown.observe(lambda x: update_plot(plot_function, [ls, x['new']],
@@ -183,13 +189,13 @@ def interactive_explore(ls):
 
     tabs = widgets.Tab()
     tabs.children = [create_distribution_plot_widget(ls),
-                     create_cdf_plot_widget(ls),
-                     create_pairdensity_plot_widget(ls),
-                     create_correlation_plot_widget(ls)]
+                     create_cdf_plot_widget(ls)]
+#                     create_pairdensity_plot_widget(ls),
+#                     create_correlation_plot_widget(ls)]
 
     tabs.set_title(0, 'Distribution')
     tabs.set_title(1, 'CDF')
-    tabs.set_title(2, 'Pairwise density')
-    tabs.set_title(3, 'Correlation matrix')
+#    tabs.set_title(2, 'Pairwise density')
+#    tabs.set_title(3, 'Correlation matrix')
 
     return tabs

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -60,20 +60,20 @@ def create_correlation_plot_widget(ls):
                         height='{:.0f}px'.format(fig.layout['height']))
 
 
-def update_plot(f, args, output_widget, **kwargs):
-    """Updates the content of an html_area with rendered function"""
+def update_plot(f, args, plot_area, **kwargs):
+    """Updates the content of an output widget with rendered function"""
 
-    figure = f(*args)
-    figure.set_size_inches(PLOT_WIDTH / DPI, PLOT_HEIGHT / DPI)
-    output_widget.clear_output()
+    fig = f(*args)
+    fig.set_size_inches(PLOT_WIDTH / DPI, PLOT_HEIGHT / DPI)
+    plot_area.clear_output()
 
     if 'height' in kwargs.keys():
-        output_widget.layout.height = '{:.0f}px'.format(kwargs['height'])
+        plot_area.layout.height = '{:.0f}px'.format(kwargs['height'])
     if 'width' in kwargs.keys():
-        output_widget.layout.width = '{:.0f}px'.format(kwargs['width'])
+        plot_area.layout.width = '{:.0f}px'.format(kwargs['width'])
 
-    with output_widget:
-        display(figure)
+    with plot_area:
+        display(fig)
 
 
 def _update_pairdensity_plot(ls, dd1, dd2, plot_area):

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -8,7 +8,7 @@ from ipywidgets import widgets
 from IPython.display import display
 from lens.plotting import (plot_distribution,
                            plot_cdf,
-                           plot_pairdensity,
+                           plot_pairdensity_mpl,
                            plot_correlation)
 
 logger = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ def update_plot(f, args, output_widget, **kwargs):
 
 def _update_pairdensity_plot(ls, dd1, dd2, plot_area):
     if dd1.value != dd2.value:
-        update_plot(plot_pairdensity,
+        update_plot(plot_pairdensity_mpl,
                     [ls, dd1.value, dd2.value],
                     plot_area, height=600, width=600)
 
@@ -104,7 +104,7 @@ def create_pairdensity_plot_widget(ls):
     if len(numeric_columns) > 1:
         dropdown1.value, dropdown2.value = numeric_columns[:2]
 
-    plot_area = widgets.HTML()
+    plot_area = widgets.Output()
 
     for dropdown in [dropdown1, dropdown2]:
         dropdown.observe(lambda x: _update_pairdensity_plot(ls, dropdown1,
@@ -194,13 +194,13 @@ def interactive_explore(ls):
 
     tabs = widgets.Tab()
     tabs.children = [create_distribution_plot_widget(ls),
-                     create_cdf_plot_widget(ls)]
-#                     create_pairdensity_plot_widget(ls),
+                     create_cdf_plot_widget(ls),
+                     create_pairdensity_plot_widget(ls)]
 #                     create_correlation_plot_widget(ls)]
 
     tabs.set_title(0, 'Distribution')
     tabs.set_title(1, 'CDF')
-#    tabs.set_title(2, 'Pairwise density')
+    tabs.set_title(2, 'Pairwise density')
 #    tabs.set_title(3, 'Correlation matrix')
 
     return tabs

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -35,7 +35,7 @@ def update_plot(f, args, plot_area, **kwargs):
     dpi = kwargs.get('dpi', DPI)
 
     fig.set_size_inches(width / dpi, height / dpi)
-    
+
     plot_area.layout.height = '{:.0f}px'.format(height)
     plot_area.layout.width = '{:.0f}px'.format(width)
 
@@ -59,11 +59,8 @@ def create_correlation_plot_widget(ls):
 
     plot_area = widgets.Output()
 
-    update_plot(plot_correlation_mpl,
-        [ls],
-        plot_area,
-        height=PLOT_WIDTH, width=PLOT_WIDTH*1.3
-        )
+    update_plot(plot_correlation_mpl, [ls], plot_area,
+                height=PLOT_WIDTH, width=PLOT_WIDTH*1.3)
 
     return plot_area
 

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -62,7 +62,7 @@ def create_correlation_plot_widget(ls):
     update_plot(plot_correlation_mpl,
         [ls],
         plot_area,
-        height=PLOT_WIDTH, width=PLOT_WIDTH
+        height=PLOT_WIDTH, width=PLOT_WIDTH*1.3
         )
 
     return plot_area

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import plotly
 import plotly.offline as py
 from ipywidgets import widgets
-
+from IPython.display import display
 from lens.plotting import (plot_distribution,
                            plot_cdf,
                            plot_pairdensity,
@@ -56,10 +56,10 @@ def create_correlation_plot_widget(ls):
                         height='{:.0f}px'.format(fig.layout['height']))
 
 
-def update_plot(f, args, html_area, **kwargs):
+def update_plot(f, args, output_widget, **kwargs):
     """Updates the content of an html_area with rendered function"""
 
-    figure = f(*args, **kwargs)    
+    figure = f(*args)    
     output_widget.clear_output()
     
     if 'height' in kwargs.keys():

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -1,9 +1,6 @@
 from __future__ import division
 import sys
 import logging
-import matplotlib.pyplot as plt
-import plotly
-import plotly.offline as py
 from ipywidgets import widgets
 from IPython.display import display
 from lens.plotting import (plot_distribution,
@@ -174,12 +171,6 @@ def interactive_explore(ls):
                    ' Jupyter notebook')
         logger.error(message)
         raise ValueError(message)
-    else:
-        # This is a bit of a hack, but it is the only place where the state of
-        # plotly initialization is stored. We need to do it because otherwise
-        # plotly fails silently if the notebook mode is not initialized.
-        if not py.offline.__PLOTLY_OFFLINE_INITIALIZED:
-            py.init_notebook_mode()
 
     tabs = widgets.Tab()
     tabs.children = [create_distribution_plot_widget(ls),

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -9,7 +9,7 @@ from IPython.display import display
 from lens.plotting import (plot_distribution,
                            plot_cdf,
                            plot_pairdensity_mpl,
-                           plot_correlation)
+                           plot_correlation_mpl)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -22,42 +22,6 @@ PADDING = '10px'
 PLOT_HEIGHT = 400
 PLOT_WIDTH = 600
 DPI = 72
-
-
-def render_plotly_js(fig, width=800, height=600):
-    """Return the plotly html for a plot"""
-    if isinstance(fig, plt.Axes):
-        fig = fig.figure
-    else:
-        fig = fig
-
-    if isinstance(fig, plt.Figure):
-        fig = plotly.tools.mpl_to_plotly(fig, strip_style=True, resize=True)
-
-    fig.layout['width'] = width
-    fig.layout['height'] = height
-
-    return py.plot(fig, output_type='div', include_plotlyjs=False,
-                   show_link=False)
-
-
-def create_correlation_plot_widget(ls):
-    """Return a widget with correlation plot.
-
-    Parameters
-    ----------
-    ls : :class:`~lens.Summary`
-        Lens `Summary`.
-
-    Returns
-    -------
-    :class:`ipywidgets.Widget`
-        Jupyter widget to explore correlation matrix plot.
-    """
-    fig = plot_correlation(ls)
-    return widgets.HTML(render_plotly_js(fig, width=fig.layout['width'],
-                                         height=fig.layout['height']),
-                        height='{:.0f}px'.format(fig.layout['height']))
 
 
 def update_plot(f, args, plot_area, **kwargs):
@@ -74,6 +38,31 @@ def update_plot(f, args, plot_area, **kwargs):
 
     with plot_area:
         display(fig)
+
+
+def create_correlation_plot_widget(ls):
+    """Return a widget with correlation plot.
+
+    Parameters
+    ----------
+    ls : :class:`~lens.Summary`
+        Lens `Summary`.
+
+    Returns
+    -------
+    :class:`ipywidgets.Widget`
+        Jupyter widget to explore correlation matrix plot.
+    """
+
+    plot_area = widgets.Output()
+
+    update_plot(plot_correlation_mpl,
+        [ls],
+        plot_area,
+        height=PLOT_HEIGHT, width=PLOT_HEIGHT
+        )
+
+    return plot_area
 
 
 def _update_pairdensity_plot(ls, dd1, dd2, plot_area):
@@ -195,12 +184,12 @@ def interactive_explore(ls):
     tabs = widgets.Tab()
     tabs.children = [create_distribution_plot_widget(ls),
                      create_cdf_plot_widget(ls),
-                     create_pairdensity_plot_widget(ls)]
-#                     create_correlation_plot_widget(ls)]
+                     create_pairdensity_plot_widget(ls),
+                     create_correlation_plot_widget(ls)]
 
     tabs.set_title(0, 'Distribution')
     tabs.set_title(1, 'CDF')
     tabs.set_title(2, 'Pairwise density')
-#    tabs.set_title(3, 'Correlation matrix')
+    tabs.set_title(3, 'Correlation matrix')
 
     return tabs

--- a/lens/widget.py
+++ b/lens/widget.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import sys
 import logging
 import matplotlib.pyplot as plt
@@ -18,6 +19,9 @@ logger.addHandler(logging.StreamHandler())
 IN_NOTEBOOK = 'ipykernel' in sys.modules
 
 PADDING = '10px'
+PLOT_HEIGHT = 400
+PLOT_WIDTH = 600
+DPI = 72
 
 
 def render_plotly_js(fig, width=800, height=600):
@@ -59,14 +63,15 @@ def create_correlation_plot_widget(ls):
 def update_plot(f, args, output_widget, **kwargs):
     """Updates the content of an html_area with rendered function"""
 
-    figure = f(*args)    
+    figure = f(*args)
+    figure.set_size_inches(PLOT_WIDTH / DPI, PLOT_HEIGHT / DPI)
     output_widget.clear_output()
-    
+
     if 'height' in kwargs.keys():
         output_widget.layout.height = '{:.0f}px'.format(kwargs['height'])
     if 'width' in kwargs.keys():
         output_widget.layout.width = '{:.0f}px'.format(kwargs['width'])
-        
+
     with output_widget:
         display(figure)
 
@@ -117,10 +122,10 @@ def _simple_columnwise_widget(ls, plot_function, columns):
 
     dropdown = widgets.Dropdown(options=columns, description='Column:')
     plot_area = widgets.Output()
-    update_plot(plot_function, [ls, columns[0]], plot_area, height=500)
+    update_plot(plot_function, [ls, columns[0]], plot_area, height=PLOT_HEIGHT)
 
     dropdown.observe(lambda x: update_plot(plot_function, [ls, x['new']],
-                                           plot_area, height=500),
+                                           plot_area, height=PLOT_HEIGHT),
                      names='value', type='change')
 
     return widgets.VBox([dropdown, plot_area], padding=PADDING)

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
         'plotly',
         'scipy',
         'tdigest',
+        'seaborn',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     install_requires=[
         'dask[dataframe,delayed]',
-        'ipywidgets',
+        'ipywidgets>=6.0.0',
         'matplotlib',
         'numpy>=1.11',
         'pandas',


### PR DESCRIPTION
Plotly interactive plots were no longer displayable in HTML widgets as of ipywidgets 6.0.0. Changed plots to use matplotlib allowing them to be displayed in ipython output widgets.

Fixes issue #6 