### PR TITLE
Import get_sync from dask.local

### DIFF
--- a/lens/summarise.py
+++ b/lens/summarise.py
@@ -11,7 +11,7 @@ import scipy.interpolate
 
 from dask.multiprocessing import get as get_multiprocessing
 from dask.threaded import get as get_threaded
-from dask.async import get_sync
+from dask.local import get_sync
 
 from .dask_graph import create_dask_graph
 from .tdigest_utils import tdigest_from_centroids

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     zip_safe=False,
     long_description=LONG_DESCRIPTION,
     install_requires=[
-        'dask[dataframe,delayed]',
+        'dask[dataframe,delayed]>=0.15.0',
         'ipywidgets>=6.0.0',
         'matplotlib',
         'numpy>=1.11',


### PR DESCRIPTION
The `sync` scheduler in dask used to be located in the `dask.async` module, but since async became a python keyword, it has been moved in dask 0.15.0 to the `dask.local` module. This PR changes the import path and sets a minimum version of dask to ensure that `dask.local` is present.