### PR TITLE
Fix plotly deprecated warning.

### DIFF
--- a/lens/plotting.py
+++ b/lens/plotting.py
@@ -3,10 +3,7 @@ from matplotlib.ticker import FuncFormatter, MaxNLocator
 import numpy as np
 import plotly.graph_objs as go
 import seaborn as sns
-try:
-    import plotly.figure_factory as pff
-except ImportError:
-    from plotly.tools import FigureFactory as pff
+import plotly.figure_factory as pff
 
 DEFAULT_COLORSCALE = 'Viridis'
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'matplotlib',
         'numpy>=1.11',
         'pandas',
-        'plotly',
+        'plotly>=2.0.0',
         'scipy',
         'tdigest',
         'seaborn',


### PR DESCRIPTION
In version 2.0, the plotly figure factory moved from `plotly.tools.FigureFactory` to `plotly.figure_factory`. This PR requires plotly 2.0 to be installed and uses only the new API, as opposed to the old try/except import block to support both versions.

Fixes #16.