### PR TITLE
Fix exception thrown on zero-row dataframe

### DIFF
--- a/lens/metrics.py
+++ b/lens/metrics.py
@@ -86,7 +86,8 @@ def column_properties(series):
     name = series.name
     colresult = {}
     colresult['dtype'] = str(series.dtype)
-    colresult['nulls'] = int(series.isnull().sum())
+    nulls = series.isnull().sum()
+    colresult['nulls'] = int(nulls) if not np.isnan(nulls) else 0
     notnulls = series.dropna()
 
     colresult['notnulls'] = len(notnulls.index)


### PR DESCRIPTION
Because of a change in pandas API, `pd.Series.sum()` now returns NaN for a zero-length series, so that casting that to an integer failed in the `column_properties` metric. This had been caught in tests in master, so there is no need to add an extra test.