### PR TITLE
Change how the dask scheduler gets passed to the compute method

### DIFF
--- a/lens/summarise.py
+++ b/lens/summarise.py
@@ -7,12 +7,6 @@ import numpy as np
 import logging
 import json
 
-import scipy.interpolate
-
-from dask.multiprocessing import get as get_multiprocessing
-from dask.threaded import get as get_threaded
-from dask.local import get_sync
-
 from .dask_graph import create_dask_graph
 from .tdigest_utils import tdigest_from_centroids
 from .utils import hierarchical_ordering
@@ -796,15 +790,7 @@ def summarise(df, scheduler='multiprocessing', num_workers=None,
             # NUM_CPUS not in environment
             num_workers = None
 
-    schedulers = {'multiprocessing': get_multiprocessing,
-                  'threaded': get_threaded,
-                  'sync': get_sync}
-
-    try:
-        kwargs = {'get': schedulers[scheduler]}
-    except KeyError:
-        raise KeyError('`scheduler` must be one of {}'
-                       .format(schedulers.keys()))
+    kwargs = {'scheduler': scheduler}
     if num_workers is not None:
         kwargs['num_workers'] = num_workers
 

--- a/lens/summarise.py
+++ b/lens/summarise.py
@@ -750,8 +750,8 @@ def summarise(df, scheduler='multiprocessing', num_workers=None,
     df : pd.DataFrame
         DataFrame to be analysed.
     scheduler : str, optional
-        Dask scheduler to use. Must be one of ['multiprocessing',
-        'threaded', 'sync'].
+        Dask scheduler to use. Must be one of [distributed, multiprocessing,
+        processes, single-threaded, sync, synchronous, threading, threads].
     num_workers : int or None, optional
         Number of workers in the pool. If the environment variable `NUM_CPUS`
         is set that number will be used, otherwise it will use as many workers

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     zip_safe=False,
     long_description=LONG_DESCRIPTION,
     install_requires=[
-        'dask[dataframe,delayed]>=0.15.0',
+        'dask[dataframe,delayed]>=0.18.0',
         'ipywidgets>=6.0.0',
         'matplotlib',
         'numpy>=1.11',


### PR DESCRIPTION
Dask has changed its API for all compute methods so that the scheduler is not passed anymore as a function in the `get` keyword but as a string in the `scheduler` keyword. This matches our `scheduler` keyword in `summarise`, so now we only need to pass it through instead of matching it to get functions.