### PR TITLE
Update plotly categorical axis type name

### DIFF
--- a/lens/metrics.py
+++ b/lens/metrics.py
@@ -741,7 +741,7 @@ def pairdensity(df, column_props, column_summ, freq, log_transform=True):
     bandwidths = [None, None]
     for col in [col1, col2]:
         if column_props[col]['is_categorical']:
-            scales.append('cat')
+            scales.append('category')
             coord_ranges.append(None)
             categories.append(sorted(list(freq[col][col].keys())))
         else:
@@ -751,7 +751,7 @@ def pairdensity(df, column_props, column_summ, freq, log_transform=True):
                 [column_summ[col][col][extreme] for extreme in ['min', 'max']])
             categories.append(None)
 
-    Ncat = np.sum([scale == 'cat' for scale in scales])
+    Ncat = np.sum([scale == 'category' for scale in scales])
 
     if N == 0:
         logger.warning('{}: No valid pairs found!'.format(log_string))

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'matplotlib',
         'numpy>=1.11',
         'pandas',
-        'plotly>=2.0.0',
+        'plotly>=3.0.0',
         'scipy',
         'tdigest',
         'seaborn',


### PR DESCRIPTION
On plotly >= 3.0, the axis type for categorical variables has changed from `cat` to `category`. This PR makes that change and increases the required version of plotly. 