### PR TITLE
Update APIs of dependencies

### DIFF
--- a/lens/metrics.py
+++ b/lens/metrics.py
@@ -188,7 +188,7 @@ def _tdigest_norm_kstest(digest):
     normdigest = _tdigest_normalise(digest)
 
     x = np.linspace(-3, 3, 500)
-    dig_q = np.array([normdigest.quantile(xx) for xx in x])
+    dig_q = np.array([normdigest.cdf(xx) for xx in x])
     norm_q = stats.norm.cdf(x)
 
     D = np.max(np.abs(dig_q - norm_q))

--- a/lens/metrics.py
+++ b/lens/metrics.py
@@ -741,7 +741,7 @@ def pairdensity(df, column_props, column_summ, freq, log_transform=True):
     bandwidths = [None, None]
     for col in [col1, col2]:
         if column_props[col]['is_categorical']:
-            scales.append('cat')
+            scales.append('category')
             coord_ranges.append(None)
             categories.append(sorted(list(freq[col][col].keys())))
         else:
@@ -751,7 +751,7 @@ def pairdensity(df, column_props, column_summ, freq, log_transform=True):
                 [column_summ[col][col][extreme] for extreme in ['min', 'max']])
             categories.append(None)
 
-    Ncat = np.sum([scale == 'cat' for scale in scales])
+    Ncat = np.sum([scale == 'category' for scale in scales])
 
     if N == 0:
         logger.warning('{}: No valid pairs found!'.format(log_string))

--- a/lens/summarise.py
+++ b/lens/summarise.py
@@ -1,11 +1,13 @@
 """Summarise a Pandas DataFrame"""
 
-import time
-import os
-import pandas as pd
-import numpy as np
-import logging
 import json
+import logging
+import os
+import time
+
+import numpy as np
+import pandas as pd
+import scipy
 
 from .dask_graph import create_dask_graph
 from .tdigest_utils import tdigest_from_centroids

--- a/lens/summarise.py
+++ b/lens/summarise.py
@@ -7,12 +7,6 @@ import numpy as np
 import logging
 import json
 
-import scipy.interpolate
-
-from dask.multiprocessing import get as get_multiprocessing
-from dask.threaded import get as get_threaded
-from dask.local import get_sync
-
 from .dask_graph import create_dask_graph
 from .tdigest_utils import tdigest_from_centroids
 from .utils import hierarchical_ordering
@@ -796,15 +790,7 @@ def summarise(df, scheduler='multiprocessing', num_workers=None,
             # NUM_CPUS not in environment
             num_workers = None
 
-    schedulers = {'multiprocessing': get_multiprocessing,
-                  'threaded': get_threaded,
-                  'sync': get_sync}
-
-    try:
-        kwargs = {'get': schedulers[scheduler]}
-    except KeyError:
-        raise KeyError('`scheduler` must be one of {}'
-                       .format(schedulers.keys()))
+    kwargs = {'scheduler': scheduler}
     if num_workers is not None:
         kwargs['num_workers'] = num_workers
 

--- a/lens/summarise.py
+++ b/lens/summarise.py
@@ -612,7 +612,7 @@ class Summary(object):
             Function representing the cdf.
         """
         tdigest = self.tdigest(column)
-        return tdigest.quantile
+        return tdigest.cdf
 
     def correlation_matrix(self, include=None, exclude=None):
         """ Correlation matrix for numeric columns

--- a/lens/summarise.py
+++ b/lens/summarise.py
@@ -750,8 +750,8 @@ def summarise(df, scheduler='multiprocessing', num_workers=None,
     df : pd.DataFrame
         DataFrame to be analysed.
     scheduler : str, optional
-        Dask scheduler to use. Must be one of ['multiprocessing',
-        'threaded', 'sync'].
+        Dask scheduler to use. Must be one of [distributed, multiprocessing,
+        processes, single-threaded, sync, synchronous, threading, threads].
     num_workers : int or None, optional
         Number of workers in the pool. If the environment variable `NUM_CPUS`
         is set that number will be used, otherwise it will use as many workers

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'matplotlib',
         'numpy>=1.11',
         'pandas',
-        'plotly>=2.0.0',
+        'plotly>=3.0.0',
         'scipy',
         'tdigest',
         'seaborn',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     zip_safe=False,
     long_description=LONG_DESCRIPTION,
     install_requires=[
-        'dask[dataframe,delayed]>=0.15.0',
+        'dask[dataframe,delayed]>=0.18.0',
         'ipywidgets>=6.0.0',
         'matplotlib',
         'numpy>=1.11',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'pandas',
         'plotly>=3.0.0',
         'scipy',
-        'tdigest',
+        'tdigest>=0.5.0',
         'seaborn',
     ],
 )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -39,7 +39,7 @@ def df(request):
         ('nulls', [np.nan, ] * nrows)
     ]
 
-    df = pd.DataFrame.from_items(items)
+    df = pd.DataFrame.from_dict(dict(items))
 
     # sprinkle nrows/50 nulls
     ncols = len(df.columns)

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -313,7 +313,7 @@ def test_dask_compute_graph_default(report):
 @pytest.mark.parametrize('scheduler,num_workers,pairdensities', [
     ('sync', None, True),
     ('multiprocessing', 2, True),
-    ('threaded', None, True),
+    ('threading', None, True),
     ('multiprocessing', 4, False),
 ])
 def test_dask_compute_graph(df, scheduler, num_workers, pairdensities):

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -55,7 +55,7 @@ def test_one_row_dataframe():
         ('d', [datetime.datetime.now()])
     ]
     columns = sorted([item[0] for item in items])
-    df = pd.DataFrame.from_items(items)
+    df = pd.DataFrame.from_dict(dict(items))
     report = summarise(df)._report
     assert sorted(report['_columns']) == columns
     column_properties = report['column_properties']
@@ -340,10 +340,10 @@ def test_empty_df():
 @pytest.fixture
 def small_df():
     N = 100
-    df = pd.DataFrame.from_items([
-        ('foo', np.random.randn(N)),
-        ('bar', np.random.randint(10, size=N))
-    ])
+    df = pd.DataFrame.from_dict({
+        'foo': np.random.randn(N),
+        'bar': np.random.randint(10, size=N)
+    })
     return df
 
 

--- a/tests/test_summary_class.py
+++ b/tests/test_summary_class.py
@@ -174,7 +174,7 @@ def test_correlation_matrix(report, ls, col1, col2):
 
 def test_correlation_matrix_one_column():
     column_values = np.random.ranf(size=200)
-    df = pd.DataFrame.from_items([('a', column_values)])
+    df = pd.DataFrame.from_dict({'a': column_values})
     summary = summarise(df)
     columns, correlation_matrix = summary.correlation_matrix()
     assert columns == ['a']
@@ -185,10 +185,10 @@ def test_correlation_matrix_one_column():
 def test_correlation_matrix_two_columns():
     column1_values = np.random.ranf(size=200)
     column2_values = np.random.ranf(size=200)
-    df = pd.DataFrame.from_items([
-        ('a', column1_values),
-        ('b', column2_values)
-    ])
+    df = pd.DataFrame.from_dict({
+        'a': column1_values,
+        'b': column2_values
+    })
     summary = summarise(df)
     columns, correlation_matrix = summary.correlation_matrix()
     assert sorted(columns) == ['a', 'b']
@@ -204,7 +204,7 @@ def test_correlation_matrix_two_columns():
 def test_correlation_matrix_three_columns():
     column_values = [np.random.ranf(size=200) for i in range(3)]
     column_headers = ['a', 'b', 'c']
-    df = pd.DataFrame.from_items(zip(column_headers, column_values))
+    df = pd.DataFrame.from_dict(dict(zip(column_headers, column_values)))
     summary = summarise(df)
     columns, correlation_matrix = summary.correlation_matrix()
     assert sorted(columns) == column_headers


### PR DESCRIPTION
This PR updates the APIs of libraries used in lens:

- tdigest: `TDigest.quantile` was renamed to `TDigest.cdf` in version 0.5.0.
- dask: scheduler is now set using `scheduler` keyword and passing a string (as we do in lens) in version 0.18.0, not a `get`  keyword that requires a function.
- plotly: categorical axis types are called `category` instead of `cat` after version 3.0.