### PR TITLE
Use NumpyEncoder for JSON serialization of report

### DIFF
--- a/lens/summarise.py
+++ b/lens/summarise.py
@@ -65,6 +65,18 @@ def _validate_report(report, schema_version):
             )
 
 
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        else:
+            return super(NumpyEncoder, self).default(obj)
+
+
 class Summary(object):
     """A summary of a pandas DataFrame.
 
@@ -128,13 +140,22 @@ class Summary(object):
            JSON serialization of the summary report
         """
         if file is None:
-            return json.dumps(self._report, separators=(",", ":"))
+            return json.dumps(
+                self._report, separators=(",", ":"), cls=NumpyEncoder
+            )
         else:
             if hasattr(file, "write"):
-                json.dump(self._report, file, separators=(",", ":"))
+                json.dump(
+                    self._report, file, separators=(",", ":"), cls=NumpyEncoder
+                )
             else:
                 with open(file, "w") as f:
-                    json.dump(self._report, f, separators=(",", ":"))
+                    json.dump(
+                        self._report,
+                        f,
+                        separators=(",", ":"),
+                        cls=NumpyEncoder,
+                    )
 
     @property
     def columns(self):

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 
 from lens import summarise, metrics, __version__
-from lens.summarise import EmptyDataFrameError
+from lens.summarise import EmptyDataFrameError, NumpyEncoder
 from lens.dask_graph import _join_dask_results
 from lens.metrics import CAT_FRAC_THRESHOLD
 from fixtures import df, report  # noqa
@@ -33,7 +33,7 @@ def test_dask_row_count(df):
     assert rc_report["unique"] == len(df.drop_duplicates().index)
 
     # test serialization
-    json.dumps({"row_count": rc_report})
+    json.dumps({"row_count": rc_report}, cls=NumpyEncoder)
 
 
 def test_zero_rows_dataframe():
@@ -111,7 +111,7 @@ def test_dask_column_properties(column_properties):
 
     # test serialization
     joined = _join_dask_results(column_properties.values()).compute()
-    json.dumps({"column_summary": joined})
+    json.dumps({"column_summary": joined}, cls=NumpyEncoder)
 
 
 def test_dask_column_summary(df, column_summary):
@@ -197,7 +197,7 @@ def test_dask_column_summary(df, column_summary):
 
     # test serialization
     joined = _join_dask_results(column_summary.values()).compute()
-    json.dumps({"column_summary": joined})
+    json.dumps({"column_summary": joined}, cls=NumpyEncoder)
 
 
 def test_dask_outliers(df, column_summary):
@@ -207,7 +207,7 @@ def test_dask_outliers(df, column_summary):
 
     # test serialization
     joined = _join_dask_results(reps).compute()
-    json.dumps({"outliers": joined})
+    json.dumps({"outliers": joined}, cls=NumpyEncoder)
 
 
 @pytest.fixture(scope="module")
@@ -233,7 +233,7 @@ def test_dask_frequencies(df, frequencies):
 
     # test serialization
     joined = _join_dask_results(frequencies.values()).compute()
-    json.dumps({"freqs": joined})
+    json.dumps({"freqs": joined}, cls=NumpyEncoder)
 
 
 def test_dask_correlation(df, column_properties):
@@ -248,7 +248,7 @@ def test_dask_correlation(df, column_properties):
     assert sp.shape[1] == len(cols)
 
     # test serialization
-    json.dumps({"correlation": rep})
+    json.dumps({"correlation": rep}, cls=NumpyEncoder)
 
 
 def test_dask_pairdensity(df, column_properties, column_summary, frequencies):
@@ -282,7 +282,7 @@ def test_dask_pairdensity(df, column_properties, column_summary, frequencies):
     joined = _join_dask_results(pds).compute()
 
     # test serialization
-    json.dumps({"pairdensity": joined})
+    json.dumps({"pairdensity": joined}, cls=NumpyEncoder)
 
 
 def should_pair_density_norm_be_finite(df, column_properties):
@@ -306,7 +306,7 @@ def serialize_full_report(dreport, fname=None):
     # test that it can be serialized as json
     try:
         if fname is None:
-            json.dumps(dreport)
+            json.dumps(dreport, cls=NumpyEncoder)
         else:
             with open(fname, "w") as f:
                 json.dump(dreport, f, indent=2)
@@ -314,7 +314,7 @@ def serialize_full_report(dreport, fname=None):
         # Nail down which metric is failing
         for k in dreport.keys():
             try:
-                json.dumps({k: dreport[k]})
+                json.dumps({k: dreport[k]}, cls=NumpyEncoder)
             except TypeError as e:
                 raise TypeError(
                     "Metric {} is not JSON serializable: {}".format(k, e)


### PR DESCRIPTION
Before we needed to convert all numpy types into Python types to be able to serialize the report into JSON. Using this encoder removes that need and will make the code in the metrics easier to read.

This encoder automatically converts np.integer into ints, np.floating into floats and np.ndarray into lists (using the `tolist` method of arrays).