### PR TITLE
WIP: Allow dask dataframes as input to lens.summarise

### DIFF
--- a/lens/metrics.py
+++ b/lens/metrics.py
@@ -474,7 +474,7 @@ def frequencies(series, column_props):
 
     if column_props[name]["is_categorical"]:
         logger.debug("frequencies - " + series.name)
-        freqs = _compute_frequencies(series.values)
+        freqs = _compute_frequencies(series.dropna().values)
         return {name: freqs, "_columns": [name]}
     else:
         return None

--- a/lens/metrics.py
+++ b/lens/metrics.py
@@ -474,7 +474,7 @@ def frequencies(series, column_props):
 
     if column_props[name]["is_categorical"]:
         logger.debug("frequencies - " + series.name)
-        freqs = _compute_frequencies(series)
+        freqs = _compute_frequencies(series.values)
         return {name: freqs, "_columns": [name]}
     else:
         return None

--- a/lens/metrics.py
+++ b/lens/metrics.py
@@ -86,15 +86,15 @@ def column_properties(series):
     name = series.name
     colresult = {}
     colresult["dtype"] = str(series.dtype)
-    nulls = series.isnull().sum()
+    nulls = series.isnull().sum().compute()
     colresult["nulls"] = int(nulls) if not np.isnan(nulls) else 0
     notnulls = series.dropna()
 
-    colresult["notnulls"] = len(notnulls.index)
+    colresult["notnulls"] = int(notnulls.index.size.compute())
     colresult["numeric"] = (
         series.dtype in [np.float64, np.int64] and colresult["notnulls"] > 0
     )
-    unique = notnulls.unique().size
+    unique = int(notnulls.unique().size.compute())
     colresult["unique"] = unique
     colresult["is_categorical"] = False
     if (

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,6 +9,7 @@ from lens.dask_graph import create_dask_graph
 
 import numpy as np
 import pandas as pd
+import dask.dataframe as dd
 from scipy import stats
 import pytest
 
@@ -60,7 +61,7 @@ def df(request):
 
     df.to_csv(dirname + "/test_results/test_data.csv", index=False)
 
-    return df
+    return dd.from_pandas(df, npartitions=4)
 
 
 def gen_categoricalint_with_no_twos(nrows):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -79,7 +79,7 @@ def gen_poisson_distributed_categorical_data(ncategories, size):
         np.random.poisson(ncategories / 2.0) for i in range(size)
     ]
     truncated_random_samples = [
-        max(min(0, sample), ncategories - 1) for sample in random_samples
+        min(max(0, sample), ncategories - 1) for sample in random_samples
     ]
     sampled_categories = [
         categories[sample] for sample in truncated_random_samples
@@ -92,13 +92,8 @@ def gen_uniformly_distributed_categorical_data(ncategories, size):
         str(i) + "".join(random.sample(string.ascii_letters, 4))
         for i in range(ncategories)
     ]
-    random_samples = np.random.randint(0, len(categories), size=size)
-    truncated_random_samples = [
-        max(min(0, sample), ncategories - 1) for sample in random_samples
-    ]
-    sampled_categories = [
-        categories[sample] for sample in truncated_random_samples
-    ]
+    random_samples = np.random.randint(0, ncategories, size=size)
+    sampled_categories = [categories[sample] for sample in random_samples]
     return sampled_categories
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,15 +1,7 @@
 boto3
 cloudpickle
-dask
 flake8
-ipywidgets
-matplotlib
-numpy
-pandas
-patsy
-plotly
 pytest
 s3fs
-scipy
 statsmodels
 toolz

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py36, py37
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 [testenv]
 sitepackages = False


### PR DESCRIPTION
This is work in progress: DO NOT MERGE

This PR adapts the summarise functionality to be able to take a [dask dataframe](https://dask.pydata.org/en/latest/dataframe.html), which will allow to take in larger-than-memory datasets and parallelise operations within the metrics and not only between metrics.

Fixes #12.