### PR TITLE
Use HTTPS links to SherlockML documentation

### DIFF
--- a/docs/source/room_occupancy_example.ipynb
+++ b/docs/source/room_occupancy_example.ipynb
@@ -109,7 +109,7 @@
     "columns in the DataFrame. It will use all cores available on the machine, so you \n",
     "might want to use a SherlockML instance with more cores to speed up the computation \n",
     "of the summary. There are additional optional parameters that can be\n",
-    "passed in. Details of these can be found in the [summarise API docs](http://docs.sherlockml.com/lens/summarise_api.html#lens.summarise.summarise).\n",
+    "passed in. Details of these can be found in the [summarise API docs](https://docs.sherlockml.com/lens/summarise_api.html#lens.summarise.summarise).\n",
     "\n",
     "Given that creating the summary is computationally intensive, *Lens* provides a way to save this summary to a JSON file on disk and recover a saved summary through the `to_json` and `from_json` methods of `lens.summary`. This allows to store it for future analysis or to share it with collaborators:"
    ]
@@ -131,7 +131,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `LensSummary` object contains the information computed from the dataset and provides methods to access both column-wise and whole dataset information. It is designed to be used programatically, and information about the methods can be accessed in the [LensSummary API docs](http://docs.sherlockml.com/lens/summarise_api.html#lens.summarise.Summary)."
+    "The `LensSummary` object contains the information computed from the dataset and provides methods to access both column-wise and whole dataset information. It is designed to be used programatically, and information about the methods can be accessed in the [LensSummary API docs](https://docs.sherlockml.com/lens/summarise_api.html#lens.summarise.Summary)."
    ]
   },
   {


### PR DESCRIPTION
The documentation is now available over HTTPS, so we should favour secure links.