### PR TITLE
Fix report compute in test fixtures

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,7 +3,6 @@ import os
 import inspect
 import random
 import string
-from dask.multiprocessing import get as mpget
 
 from lens.dask_graph import create_dask_graph
 
@@ -128,6 +127,6 @@ def gen_datetimes(size):
 @pytest.fixture(scope="module")
 def report(df):
     # Get a dict report by not calling summarise
-    report = create_dask_graph(df).compute(get=mpget)
+    report = create_dask_graph(df).compute(scheduler="multiprocessing")
 
     return report


### PR DESCRIPTION
Even though we had fixed the use of the deprecated `get` argument to dask compute in the code itself, there is still a use in the tests that triggers an error now that it has been completely deprecated.