### PR TITLE
Plotly requirements update

### DIFF
--- a/lens/explorer.py
+++ b/lens/explorer.py
@@ -43,8 +43,7 @@ def _render(fig, showlegend=None):
         logger.error(message)
         raise ValueError(message)
     else:
-        if not py.offline.__PLOTLY_OFFLINE_INITIALIZED:
-            py.init_notebook_mode()
+        py.init_notebook_mode()
         return py.iplot(fig, **PLOTLY_KWS)
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "matplotlib",
         "numpy>=1.11",
         "pandas",
-        "plotly>=3.0.0",
+        "plotly>=4.0.0",
         "scipy",
         "tdigest>=0.5.0",
         "seaborn",


### PR DESCRIPTION
PR raised in response to #44 

> Prior to version 4, this library could operate in either an "online" or "offline" mode. The documentation tended to emphasize the online mode, where graphs get published to the Chart Studio web service. In version 4, all "online" functionality was removed from the plotly package and is now available as the separate, optional, chart-studio package (See below). plotly.py version 4 is "offline" only, and does not include any functionality for uploading figures or data to cloud services.

This PR updates the plotly requirement and removed the use of a deprecated plotly attribute, tox tests were run successfully.

More details on the plotly migration to version 4 available [here](https://plot.ly/python/v4-migration/)
